### PR TITLE
Fix Collage and Update Upload

### DIFF
--- a/frontend/public/upload.html
+++ b/frontend/public/upload.html
@@ -60,7 +60,7 @@
 		<div class="container" id="upload">
             <form method="POST" action="/api/pictures" enctype="multipart/form-data">
                 <div class="field">
-                    <div class="file is-boxed">
+                    <div id="file-js-example" class="file is-boxed has-name">
                         <label class="file-label">
                             <input class="file-input" type="file" name="picture">
                             <span class="file-cta">
@@ -70,6 +70,8 @@
                                 <span class="file-label">
                                     Choose a file...
                                 </span>
+                            </span>
+                            <span class="file-name">
                             </span>
                         </label>
                     </div>
@@ -82,6 +84,18 @@
             </form>
 		</div>
 	</section>
+
+	<script>
+	// https://bulma.io/documentation/form/file/#javascript
+	const fileInput = document.querySelector('#file-js-example input[type=file]');
+	fileInput.onchange = () => {
+	  if (fileInput.files.length > 0) {
+	    const fileName = document.querySelector('#file-js-example .file-name');
+	    fileName.textContent = fileInput.files[0].name;
+	  }
+	}
+	</script>
+
 </body>
 
 </html>

--- a/services/collage/go/main.go
+++ b/services/collage/go/main.go
@@ -94,7 +94,7 @@ func handleRequest(env config) func(w http.ResponseWriter, r *http.Request) {
 		args := []string{"convert",
 			"(", localFiles[0], localFiles[1], "+append", ")",
 			"(", localFiles[2], localFiles[3], "+append", ")",
-			"-size", "400x400", "xc:none", "-background", "none", "-append",
+			"-size", "400x400", "xc:none", "-background", "none", "-append", "-trim",
 			collagePath,
 		}
 

--- a/services/collage/nodejs/index.js
+++ b/services/collage/nodejs/index.js
@@ -59,7 +59,7 @@ app.post('/', async (req, res) => {
             await convert([
                 '(', ...thumbnailPaths.slice(0, 2), '+append', ')',
                 '(', ...thumbnailPaths.slice(2), '+append', ')',
-                '-size', '400x400', 'xc:none', '-background', 'none',  '-append',
+                '-size', '400x400', 'xc:none', '-background', 'none',  '-append', '-trim',
                 collagePath]);
             console.log("Created local collage picture");
 

--- a/workflows/services/collage/nodejs/index.js
+++ b/workflows/services/collage/nodejs/index.js
@@ -59,7 +59,7 @@ app.get('/', async (req, res) => {
             await convert([
                 '(', ...thumbnailPaths.slice(0, 2), '+append', ')',
                 '(', ...thumbnailPaths.slice(2), '+append', ')',
-                '-size', '400x400', 'xc:none', '-background', 'none',  '-append',
+                '-size', '400x400', 'xc:none', '-background', 'none',  '-append', '-trim',
                 collagePath]);
             console.log("Created local collage picture");
 


### PR DESCRIPTION
Two small fixes!

### Fix Collage

Adds `-trim` to remove the excess blank space at the bottom of the generated collage, for 2 x nodejs implementations and 1 x go implementation. Does not fix the C# version as that uses a different method of montaging the images together. 

Sample change before and after, with highlighted borders

<img width="520" alt="Sample collage diff" src="https://user-images.githubusercontent.com/813732/113787886-30c83500-977f-11eb-9fdd-66386298dc96.png">



### Update Upload

Uses sample code from Bulma to display the selected filename on upload. 

Before: 

<img width="305" alt="Upload field without filename" src="https://user-images.githubusercontent.com/813732/113787713-ddee7d80-977e-11eb-912c-cb50f447611a.png">


After: 
<img width="395" alt="Upload field with filename" src="https://user-images.githubusercontent.com/813732/113787717-df1faa80-977e-11eb-8fc8-f99a40e5ca9f.png">


